### PR TITLE
Replaces base url with curl

### DIFF
--- a/R/util_functions.R
+++ b/R/util_functions.R
@@ -1,10 +1,11 @@
+require(curl)
 readUrl <- function(final_url) {
   out <- tryCatch({
     #if you want to use more than one R expression in the "try" part use {}
     # 'tryCatch()' will return the last evaluated expression 
     # in case the "try" part was completed successfully  
     #message("This is the 'try' part")  
-    u <- url(final_url)  
+    u <- curl(final_url)  
     # readLines(u, warn=FALSE) 
     readLines(u) 
     # The return value of `readLines()` is the actual value 


### PR DESCRIPTION
Appears that Weather Underground may have their knickers in a knot over page scraping?

Replaced the base url function with curl. I think that curl probably does a better job of spoofing the request headers. Thus, knickers un-knotted and weather data flowing again.

Have tested and "works on my machine"... but I will admit this is my first pull-request :-)